### PR TITLE
upgrade parallel-web to v0.4.1, enable advanced search mode by default

### DIFF
--- a/chezmoi/private_dot_pi/agent/extensions/parallel-web-tools/fetch.ts
+++ b/chezmoi/private_dot_pi/agent/extensions/parallel-web-tools/fetch.ts
@@ -90,11 +90,10 @@ export const fetchWebTool: ToolDefinition<typeof fetchWebParameters, FetchWebDet
 
     try {
       const client = getParallelClient();
-      const result = await client.beta.extract({
+      const result = await client.extract({
         urls: params.urls,
         objective: params.objective,
-        excerpts: true,
-        full_content: true,
+        advanced_settings: { full_content: true },
       });
 
       const results = Array.isArray(result.results) ? (result.results as FetchResultItem[]) : [];

--- a/chezmoi/private_dot_pi/agent/extensions/parallel-web-tools/package-lock.json
+++ b/chezmoi/private_dot_pi/agent/extensions/parallel-web-tools/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pi-parallel-web-tools",
       "version": "1.0.0",
       "dependencies": {
-        "parallel-web": "^0.3.1"
+        "parallel-web": "^0.4.1"
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.8",
@@ -851,9 +851,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -871,9 +868,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -891,9 +885,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -911,9 +902,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -1071,9 +1059,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1091,9 +1076,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1111,9 +1093,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1131,9 +1110,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1151,9 +1127,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3330,9 +3303,9 @@
       }
     },
     "node_modules/parallel-web": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/parallel-web/-/parallel-web-0.3.2.tgz",
-      "integrity": "sha512-PVCECmqn4cADf5LIWZJ+I6aeYG5/Endt3AbOJP/tWQK3Y+yobjMlmOJAhaUgJvNWXXcvqW75qapILWcEqCiMHw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/parallel-web/-/parallel-web-0.4.1.tgz",
+      "integrity": "sha512-kcBwdJxgT+m2D65P5AQ2EtdbmjrA8djoqRT4wr0WCMYnpIEzadTzwJ9zS2N/BT7wTk5rComkQ/2faSUtgZwWCg==",
       "license": "MIT"
     },
     "node_modules/parse5": {

--- a/chezmoi/private_dot_pi/agent/extensions/parallel-web-tools/package.json
+++ b/chezmoi/private_dot_pi/agent/extensions/parallel-web-tools/package.json
@@ -10,7 +10,7 @@
     ]
   },
   "dependencies": {
-    "parallel-web": "^0.3.1"
+    "parallel-web": "^0.4.1"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.8",

--- a/chezmoi/private_dot_pi/agent/extensions/parallel-web-tools/parallel.ts
+++ b/chezmoi/private_dot_pi/agent/extensions/parallel-web-tools/parallel.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import Parallel from "parallel-web";
 
 export const API_KEY_ENV = "PARALLEL_API_KEY";
-export const DEFAULT_SEARCH_MODE = "agentic";
+export const DEFAULT_SEARCH_MODE: "basic" | "advanced" = "advanced";
 export const DEFAULT_MAX_RESULTS = 5;
 export const MAX_MAX_RESULTS = 8;
 export const TMP_DIR = "/tmp/pi-parallel-fetch";

--- a/chezmoi/private_dot_pi/agent/extensions/parallel-web-tools/search.ts
+++ b/chezmoi/private_dot_pi/agent/extensions/parallel-web-tools/search.ts
@@ -89,12 +89,14 @@ export const searchWebTool: ToolDefinition<typeof searchWebParameters, SearchWeb
     try {
       const client = getParallelClient();
       const afterDate = validateAfterDate(params.after_date);
-      const result = await client.beta.search({
+      const result = await client.search({
         objective: params.objective,
         search_queries: searchQueries,
         mode: DEFAULT_SEARCH_MODE,
-        max_results: clampMaxResults(params.max_results),
-        source_policy: afterDate ? { after_date: afterDate } : undefined,
+        advanced_settings: {
+          max_results: clampMaxResults(params.max_results),
+          source_policy: afterDate ? { after_date: afterDate } : undefined,
+        },
       });
 
       const results = Array.isArray(result.results) ? (result.results as SearchResultItem[]) : [];


### PR DESCRIPTION
- Bump parallel-web from ^0.3.1 to ^0.4.1
- Switch DEFAULT_SEARCH_MODE from "agentic" (invalid) to "advanced"
- Migrate client.beta.search() → client.search() per v0.4 API
- Move max_results and source_policy under advanced_settings in search call
- Migrate client.beta.extract() → client.extract() per v0.4 API
- Move full_content into advanced_settings, drop excerpts param (now always returned)

https://claude.ai/code/session_01F2w29aRSB7WFQEVdQufjJE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated parallel-web dependency from version 0.3.1 to 0.4.1

* **Refactor**
  * Improved web search request handling and content extraction mechanisms
  * Updated default search mode to "advanced"

<!-- end of auto-generated comment: release notes by coderabbit.ai -->